### PR TITLE
Add new endpoint /freqs-by-year-streamed

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module mquery
 go 1.20
 
 require (
-	github.com/czcorpus/cnc-gokit v0.4.2
+	github.com/czcorpus/cnc-gokit v0.4.3
 	github.com/gin-gonic/gin v1.9.1
 	github.com/go-sql-driver/mysql v1.7.1
 	github.com/google/uuid v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,8 @@ github.com/chenzhuoyu/base64x v0.0.0-20211019084208-fb5309c8db06/go.mod h1:DH46F
 github.com/chenzhuoyu/base64x v0.0.0-20221115062448-fe3a3abad311 h1:qSGYFH7+jGhDF8vLC+iwCD4WpbV1EBDSzWkJODFLams=
 github.com/chenzhuoyu/base64x v0.0.0-20221115062448-fe3a3abad311/go.mod h1:b583jCggY9gE99b6G5LEC39OIiVsWj+R97kbl5odCEk=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
-github.com/czcorpus/cnc-gokit v0.4.2 h1:qcVGEOfltjFflEDr3kbgR1oWdmXzozxUvsDy1XO1+sI=
-github.com/czcorpus/cnc-gokit v0.4.2/go.mod h1:m6/pi38R7LW9Dm598fwI0UTqcCcCuLD60Tx7pidWGcc=
+github.com/czcorpus/cnc-gokit v0.4.3 h1:dDXbaOtdLxL8ElvGC7pp4JLNzuZKCdM4udfeRc7umsk=
+github.com/czcorpus/cnc-gokit v0.4.3/go.mod h1:m6/pi38R7LW9Dm598fwI0UTqcCcCuLD60Tx7pidWGcc=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/mquery.go
+++ b/mquery.go
@@ -137,6 +137,9 @@ func runApiServer(
 		"/text-types-streamed/:corpusId", concActions.TextTypesStreamed)
 
 	engine.GET(
+		"/freqs-by-year-streamed/:corpusId", concActions.FreqsByYears)
+
+	engine.GET(
 		"/text-types/:corpusId", concActions.TextTypes)
 
 	engine.GET(


### PR DESCRIPTION
We need this to be able to filter year ranges when dealing with text types containing e.g. publishing years. The endpoint is basically a more specific variant of /text-types-streamed