### PR TITLE
Fix - word forms - always return array (even for no result)

### DIFF
--- a/corpus/handlers/wforms.go
+++ b/corpus/handlers/wforms.go
@@ -107,7 +107,7 @@ func (a *Actions) findWordForms(corpusID string, lemma string, pos string) (*res
 	ans := &results.WordFormsItem{
 		Lemma: lemma,
 		POS:   pos,
-		Forms: freqs.Freqs,
+		Forms: freqs.Freqs.AlwaysAsList(),
 	}
 	return ans, nil
 }

--- a/rdb/client.go
+++ b/rdb/client.go
@@ -94,7 +94,7 @@ type ConcordanceArgs struct {
 	CorpusPath        string
 	Query             string
 	QueryLemma        string
-	Attrs             []string
+	Attrs             []string	
 	ShowStructs       []string
 	ShowRefs          []string
 	MaxItems          int

--- a/rdb/results/results.go
+++ b/rdb/results/results.go
@@ -45,6 +45,15 @@ func (flist FreqDistribItemList) Cut(maxItems int) FreqDistribItemList {
 	return flist
 }
 
+// AlwaysAsList returns an empty list in case the original
+// value is nil.
+func (flist FreqDistribItemList) AlwaysAsList() []*FreqDistribItem {
+	if flist != nil {
+		return flist
+	}
+	return []*FreqDistribItem{}
+}
+
 type FreqDistribItem struct {
 	Value string  `json:"value"`
 	Freq  int64   `json:"freq"`


### PR DESCRIPTION
This helps WaG to prevent unexpected null value error