### PR TITLE
Rename collocations-with-examples to collocations-extended and add ...

### DIFF
--- a/apiserver.go
+++ b/apiserver.go
@@ -133,7 +133,7 @@ func (api *apiServer) Start(ctx context.Context) {
 		"/collocations/:corpusId", ceActions.Collocations)
 
 	engine.GET(
-		"/collocations-with-examples/:corpusId", ceActions.CollocationsWithExamples)
+		"/collocations-extended/:corpusId", ceActions.CollocationsExtended)
 
 	engine.GET(
 		"/word-forms/:corpusId", ceActions.WordForms)

--- a/rdb/results.go
+++ b/rdb/results.go
@@ -54,3 +54,11 @@ type WorkerResult struct {
 	ProcBegin    time.Time
 	ProcEnd      time.Time
 }
+
+// WorkerResult is a flag equivalent
+// to res.Value == nil - i.e. the result
+// has no value at all (which is not the
+// same as e.g. a concordance with zero lines).
+func (res WorkerResult) IsEmpty() bool {
+	return res.Value == nil
+}


### PR DESCRIPTION
... a way to attach the same collocation args to a different corpus for comparison. The current version is limited in a way that the same CQL must be applicable to both corpora.